### PR TITLE
Construct BUILD_DATE using date -u for OSX support

### DIFF
--- a/src/version.cr
+++ b/src/version.cr
@@ -1,6 +1,6 @@
 module Shards
   VERSION = {{ `cat VERSION`.stringify.chomp }}
-  BUILD_DATE = {{ `date --utc +'%Y-%m-%d'`.stringify.chomp }}
+  BUILD_DATE = {{ `date -u +'%Y-%m-%d'`.stringify.chomp }}
 
   def self.version_string
     "Shards #{VERSION} (#{BUILD_DATE})"


### PR DESCRIPTION
I am unable to build shards on OSX due to `date --utc` being unavailable on OSX. Changed `date --utc` to `date -u` to get it to build (which should also work on linux)