### PR TITLE
Raise exception if unable to find spec file.

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -7,6 +7,9 @@ module Shards
 
     def self.from_file(path)
       path = File.join(path, SPEC_FILENAME) if File.directory?(path)
+      unless File.exists?(path)
+        raise Error.new("Error: Could not locate #{SPEC_FILENAME}")
+      end
       from_yaml(File.read(path))
     end
 


### PR DESCRIPTION
I know this is a small change but I noticed that Shards currently throws an ugly internal exception if the install command is run from a directory that is missing a `shard.yml` file.

Current Output:
```
Error opening file '.../bin/shard.yml' with mode 'r': No such file or directory (Errno)
*Errno::new<String>:Errno +426 [4416834874]
*File::new<String, String>:File +1217 [4416884113]
*File::read<String>:String +29 [4416882253]
~fun_literal_18 +2056 [4416880680]
__crystal_main +12189 [4416828125]
main +44 [4416835036]
```

This patch simply raises an error if the spec file is unable to be located in the current directory. The output of the error is much more user-friendly (in my opinion):

```
Error: Could not locate shard.yml
```