### PR TITLE
log commands that are executed

### DIFF
--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -36,6 +36,7 @@ module Shards
 
     def run_script(name)
       if installed? && (command = spec.script(name))
+        Shards.logger.info "#{name.capitalize} #{command}"
         Script.run(install_path, command)
       end
     end

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -8,7 +8,7 @@ module Shards
     def self.from_file(path)
       path = File.join(path, SPEC_FILENAME) if File.directory?(path)
       unless File.exists?(path)
-        raise Error.new("Error: Could not locate #{SPEC_FILENAME}")
+        raise Error.new("could not locate #{SPEC_FILENAME}")
       end
       from_yaml(File.read(path))
     end


### PR DESCRIPTION
It's probably a good idea to log any executed commands so that the user can verify commands.

This pull request simply logs the command as such:

```
Postinstall cd ext && make
```

This patch also fixes a small issue when run without a spec file. Previously the word `Error` was displayed twice (I submitted a PR for this earlier, but the error logging behaviour has changed since then).