### PR TITLE
Correctly parses empty Projectfile

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -30,6 +30,8 @@ module Shards
 
           if dependencies.any?
             dependencies = "dependencies:\n#{dependencies.join("\n")}"
+          else
+            dependencies = ""
           end
         end
 

--- a/test/git_resolver_test.cr
+++ b/test/git_resolver_test.cr
@@ -84,6 +84,15 @@ module Shards
       assert_equal "1-0-stable", library["branch"]
     end
 
+    def test_parses_empty_dependencies_from_projectfile
+      create_file "legacy", "Projectfile",
+        "deps do\nend"
+      create_git_release "legacy", "1.0.1", shard: false
+
+      spec = resolver("legacy").spec("1.0.1")
+      assert_equal 0, spec.dependencies.size
+    end
+
     private def resolver(name, config = {} of String => String)
       config = config.merge({ "git" => git_url(name) })
       dependency = Dependency.new(name, config)


### PR DESCRIPTION
By default, Crystal, prior to version 0.8.0, used to generate
an empty `Projectfile` with no listed dependencies:

```crystal
deps do
end
```

Developers might have committed this empty Projectfile to their
repositories, which then was parsed as legacy and attempt to build
the dependencies.

This result in an empty array of dependencies, which was incorrectly
concatenated to the fake spec built by Shards in attempt to process
legacy repositories. This was not proper YAML and thus, blow up
at runtime.

The fix provided here avoids that by resetting the empty list of
dependencies and simply return nothing, generating a proper YAML
and allowing the parsing to continue.

Fixes reported issue #42.