### PR TITLE
Spec now uses yaml_mapping (experimental)

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -51,9 +51,13 @@ begin
 
 rescue ex : OptionParser::InvalidOption
   Shards.logger.fatal ex.message
-  exit -1
+  exit 1
+
+rescue ex : Shards::ParseError
+  ex.to_s(STDERR)
+  exit 1
 
 rescue ex : Shards::Error
   Shards.logger.error ex.message
-  exit -1
+  exit 1
 end

--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -1,22 +1,41 @@
 module Shards
   class Dependency < Hash(String, String)
-    getter :name, :config
+    property :name
 
+    def self.new(pull : YAML::PullParser)
+      dependency = new(pull.read_scalar)
+      pull.read_mapping_start
+
+      while pull.kind != YAML::EventKind::MAPPING_END
+        dependency[pull.read_scalar] = pull.read_scalar
+      end
+
+      pull.read_next
+      dependency
+    #rescue YAML::ParseException
+    #  raise Exception.new("Invalid dependency definition at #{ ex.line_number }:#{ ex.column_number }")
+    end
+
+    def initialize(@name)
+      super()
+    end
+
+    # DEPRECATED: with no replacement
     def initialize(@name, config)
-      super nil
+      super()
       config.each { |k, v| self[k.to_s] = v.to_s }
     end
 
     def version
-      self["version"]? || "*"
+      fetch("version", "*")
     end
 
     def refs
-      self["commit"]? || self["tag"]? || self["branch"]?
+      self["branch"]? || self["tag"]? || self["commit"]?
     end
 
     def inspect(io)
-      io << "#<" << self.class.name << " {\"" << name << "\" => "
+      io << "#<" << self.class.name << " {" << name << " => "
       super
       io << "}>"
     end

--- a/src/errors.cr
+++ b/src/errors.cr
@@ -21,4 +21,40 @@ module Shards
       super "Unsupported #{ LOCK_FILENAME }. It was likely generated from a newer version of Shards."
     end
   end
+
+  class ParseError < Error
+    getter :input
+    getter :filename
+    getter :line_number
+    getter :column_number
+
+    def initialize(message, @input, @filename, line_number, column_number)
+      @line_number = line_number.to_i
+      @column_number = column_number.to_i
+      super message
+    end
+
+    def to_s(io)
+      io.puts "in #{ filename }:#{ line_number }: #{ self.class.name }: #{ message }"
+      io.puts
+
+      lines = input.split('\n')
+      from = line_number - 2
+      from = 0 if from < 0
+
+      lines[from .. line_number].each_with_index do |line, i|
+        io.puts "  #{ i + 1 }. #{ line }"
+      end
+
+      arrow = String.build do |s|
+        s << "     "
+        (column_number - 1).times { s << ' ' }
+        s << '^'
+      end
+      io.puts arrow.colorize(:green).bold
+      io.puts
+
+      io.flush
+    end
+  end
 end

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -2,6 +2,7 @@ require "yaml"
 require "./dependency"
 
 module Shards
+  # TODO: use yaml_mapping or YAML::PullParser directly
   module Lock
     def self.from_file(path)
       raise Error.new("Missing #{ File.basename(path) }") unless File.exists?(path)

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -23,7 +23,7 @@ module Shards
       path = File.join(local_path, SPEC_FILENAME)
       return Spec.from_file(path) if File.exists?(path)
 
-      Spec.from_yaml("name: #{dependency.name}\n")
+      Spec.from_yaml("name: #{dependency.name}\nversion: 0\n")
     end
 
     def installed_commit_hash

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -36,7 +36,7 @@ module Shards
     abstract def installed_commit_hash
 
     def run_script(name)
-      if installed? && (command = spec.script(name))
+      if installed? && (command = spec.scripts[name]?)
         Shards.logger.info "#{name.capitalize} #{command}"
         Script.run(install_path, command)
       end

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -1,4 +1,6 @@
+require "colorize"
 require "yaml"
+require "./config"
 require "./dependency"
 require "./errors"
 
@@ -21,43 +23,86 @@ module Shards
       end
     end
 
-    # :nodoc:
-    class Dependencies < Array(Dependency)
-      def self.new(pull : YAML::PullParser)
-        pull.read_mapping_start
-        dependencies = new
-
-        while pull.kind != YAML::EventKind::MAPPING_END
-          dependencies << Dependency.new(pull)
-        end
-
-        pull.read_next
-        dependencies
-      #rescue ex : YAML::ParseException
-      #  raise Exception.new("Invalid dependencies definition at #{ ex.line_number }:#{ ex.column_number }")
-      end
-    end
-
-    def self.from_file(path)
+    def self.from_file(path, validate = false)
       path = File.join(path, SPEC_FILENAME) if File.directory?(path)
       raise Error.new("Missing #{ File.basename(path) }") unless File.exists?(path)
-      from_yaml(File.read(path))
+      from_yaml(File.read(path), path, validate)
     end
 
-    yaml_mapping({
-      name: { type: String },
-      version: { type: String },
-      description: { type: String, nilable: true },
-      license: { type: String, nilable: true },
-      authors: { type: Array(Author), nilable: true },
-      scripts: { type: Hash(String, String), nilable: true },
-      dependencies: { type: Dependencies, nilable: true },
-      development_dependencies: { type: Dependencies, nilable: true },
-    })
+    def self.from_yaml(input, filename = SPEC_FILENAME, validate = false)
+      parser = YAML::PullParser.new(input)
+      parser.read_stream do
+        parser.read_document do
+          new(parser, validate)
+        end
+      end
+    rescue ex : YAML::ParseException
+      raise ParseError.new(ex.message, input, filename, ex.line_number, ex.column_number)
+    ensure
+      parser.close if parser
+    end
 
+    getter! :name
     getter! :version
+    getter :description
+    getter :license
 
-    def initialize(@name : String)
+    # :nodoc:
+    def initialize(pull : YAML::PullParser, validate = false)
+      read_mapping(pull) do
+        case key = pull.read_scalar
+        when "name"
+          @name = pull.read_scalar
+        when "version"
+          @version = pull.read_scalar
+        when "description"
+          @description = pull.read_scalar
+        when "license"
+          @license = pull.read_scalar
+        when "authors"
+          read_sequence(pull) do
+            authors << Author.new(pull.read_scalar)
+          end
+        when "dependencies"
+          read_mapping(pull) do
+            dependency = Dependency.new(pull.read_scalar)
+            read_mapping(pull) { dependency[pull.read_scalar] = pull.read_scalar }
+            dependencies << dependency
+          end
+        when "development_dependencies"
+          read_mapping(pull) do
+            dependency = Dependency.new(pull.read_scalar)
+            read_mapping(pull) { dependency[pull.read_scalar] = pull.read_scalar }
+            development_dependencies << dependency
+          end
+        when "scripts"
+          read_mapping(pull) do
+            scripts[pull.read_scalar] = pull.read_scalar
+          end
+        else
+          if validate
+            raise YAML::ParseException.new("unknown attribute: #{ key }", pull.line_number, pull.column_number)
+          else
+            pull.skip
+          end
+        end
+      end
+
+      {% for attr in %w(name version) %}
+        unless @{{ attr.id }}
+          raise YAML::ParseException.new(
+            "missing required attribute: {{ attr.id }}",
+            pull.line_number,
+            pull.column_number
+          )
+        end
+      {% end %}
+    end
+
+    def name=(@name : String)
+    end
+
+    def version=(@version : String)
     end
 
     def authors
@@ -65,27 +110,43 @@ module Shards
     end
 
     def dependencies
-      @dependencies ||= Dependencies.new
+      @dependencies ||= [] of Dependency
     end
 
     def development_dependencies
-      @development_dependencies ||= Dependencies.new
+      @development_dependencies ||= [] of Dependency
     end
 
-    def script(name)
-      if scripts = self.scripts
-        scripts[name]?
-      end
+    def scripts
+      @scripts ||= {} of String => String
     end
 
     def license_url
-      if license = self.license
+      if license = @license
         if license =~ %r(https?://)
           license
         else
           "http://opensource.org/licenses/#{ license }"
         end
       end
+    end
+
+    private def read_sequence(pull)
+      pull.read_sequence_start
+      until pull.kind == YAML::EventKind::SEQUENCE_END
+        yield
+      end
+      pull.read_next
+      nil
+    end
+
+    private def read_mapping(pull)
+      pull.read_mapping_start
+      until pull.kind == YAML::EventKind::MAPPING_END
+        yield
+      end
+      pull.read_next
+      nil
     end
   end
 end

--- a/test/integration/install_test.cr
+++ b/test/integration/install_test.cr
@@ -5,7 +5,6 @@ class InstallCommandTest < Minitest::Test
     metadata = {
       dependencies: { web: "*", orm: "*", },
       development_dependencies: { mock: "*" },
-      custom_dependencies: { release: "*" },
     }
 
     with_shard(metadata) do

--- a/test/integration/update_test.cr
+++ b/test/integration/update_test.cr
@@ -5,7 +5,6 @@ class UpdateCommandTest < Minitest::Test
     metadata = {
       dependencies: { web: "*", orm: "*", },
       development_dependencies: { mock: "*" },
-      custom_dependencies: { release: "*" },
     }
 
     with_shard(metadata) do

--- a/test/path_resolver_test.cr
+++ b/test/path_resolver_test.cr
@@ -29,12 +29,12 @@ module Shards
         legacy.install
         assert File.exists?(install_path("legacy", "legacy.cr"))
         refute File.exists?(install_path("legacy", "shard.yml"))
-        assert_empty legacy.installed_spec.not_nil!.version
+        assert_equal "0", legacy.installed_spec.not_nil!.version
       end
     end
 
     private def resolver(name, config = {} of String => String)
-      config = config.merge({ "path" => git_path(name) })
+      config["path"] = git_path(name)
       dependency = Dependency.new(name, config)
       PathResolver.new(dependency)
     end

--- a/test/spec_test.cr
+++ b/test/spec_test.cr
@@ -1,0 +1,113 @@
+require "minitest/autorun"
+require "../src/spec"
+
+module Shards
+  class SpecTest < Minitest::Test
+    def test_parse_minimal_shard
+      spec = Spec.from_yaml("name: shards\nversion: 0.1.0\n")
+      assert_equal "shards", spec.name
+      assert_equal "0.1.0", spec.version
+      assert_nil spec.description
+      assert_nil spec.license
+      assert_empty spec.authors
+    end
+
+    def test_parse_description
+      spec = Spec.from_yaml("name: shards\nversion: 0.1.0\ndescription: short description")
+      assert_equal "short description", spec.description
+
+      spec = Spec.from_yaml("name: shards\nversion: 0.1.0\ndescription: |\n slightly longer description")
+      assert_equal "slightly longer description", spec.description
+    end
+
+    def test_parse_license
+      spec = Spec.from_yaml("name: shards\nversion: 0.1.0\nlicense: BSD-2-Clause")
+      assert_equal "BSD-2-Clause", spec.license
+      assert_equal "http://opensource.org/licenses/BSD-2-Clause", spec.license_url
+
+      spec = Spec.from_yaml("name: shards\nversion: 0.1.0\nlicense: http://example.com/LICENSE")
+      assert_equal "http://example.com/LICENSE", spec.license
+      assert_equal "http://example.com/LICENSE", spec.license_url
+    end
+
+    def test_parse_authors
+      spec = Spec.from_yaml("name: shards\nversion: 0.1.0\nauthors:\n  - Julien Portalier <julien@portalier.com>\n  - Ary")
+      assert_equal 2, spec.authors.size
+
+      assert_equal "Julien Portalier", spec.authors[0].name
+      assert_equal "julien@portalier.com", spec.authors[0].email
+
+      assert_equal "Ary", spec.authors[1].name
+      assert_nil spec.authors[1].email
+    end
+
+    def test_parse_dependencies
+      spec = Spec.from_yaml <<-YAML
+  name: orm
+  version: 1.0.0
+  dependencies:
+    repo:
+      github: user/repo
+      version: 1.2.3
+    example:
+      git: https://example.com/example-crystal.git
+      branch: master
+    local:
+      path: /var/clones/local
+      tag: unreleased
+  YAML
+
+      assert_equal 3, spec.dependencies.size
+
+      assert_equal "repo", spec.dependencies[0].name
+      assert_equal "user/repo", spec.dependencies[0]["github"]
+      assert_equal "1.2.3", spec.dependencies[0].version
+      assert_nil spec.dependencies[0].refs
+
+      assert_equal "example", spec.dependencies[1].name
+      assert_equal "https://example.com/example-crystal.git", spec.dependencies[1]["git"]
+      assert_equal "*", spec.dependencies[1].version
+      assert_equal "master", spec.dependencies[1].refs
+
+      assert_equal "local", spec.dependencies[2].name
+      assert_equal "/var/clones/local", spec.dependencies[2]["path"]
+      assert_equal "*", spec.dependencies[2].version
+      assert_equal "unreleased", spec.dependencies[2].refs
+    end
+
+    def test_parse_development_dependencies
+      spec = Spec.from_yaml <<-YAML
+  name: orm
+  version: 1.0.0
+  development_dependencies:
+    minitest:
+      github: ysbaddaden/minitest.cr
+      version: 0.1.4
+    webmock:
+      git: https://github.com/manastech/webcmok-crystal.git
+      branch: master
+  YAML
+
+      assert_equal 2, spec.development_dependencies.size
+
+      assert_equal "minitest", spec.development_dependencies[0].name
+      assert_equal "ysbaddaden/minitest.cr", spec.development_dependencies[0]["github"]
+      assert_equal "0.1.4", spec.development_dependencies[0].version
+
+      assert_equal "webmock", spec.development_dependencies[1].name
+      assert_equal "https://github.com/manastech/webcmok-crystal.git", spec.development_dependencies[1]["git"]
+      assert_equal "master", spec.development_dependencies[1].refs
+    end
+
+  #  def test_fails_to_parse_dependencies
+  #    str = <<-YAML
+  #name: amethyst
+  #version: 0.1.7
+  #dependencies:
+  #  github: spalger/crystal-mime
+  #  branch: master
+  #YAML
+  #    Spec.from_yaml(str)
+  #  end
+  end
+end

--- a/test/support/mock_resolver.cr
+++ b/test/support/mock_resolver.cr
@@ -26,9 +26,9 @@ module Shards
 
     @@specs = {} of String => Hash(String, String)
 
-    def self.register_spec(name, version = nil, as = nil, dependencies = nil, development = nil)
+    def self.register_spec(name, version = "0.0.0", as = nil, dependencies = nil, development = nil)
       spec = "name: #{ name.inspect }\n"
-      spec += "version: #{ version.inspect }\n" if version
+      spec += "version: #{ version.inspect }\n"
 
       if dependencies
         spec += "dependencies:\n#{ to_yaml(dependencies) }\n"
@@ -53,9 +53,9 @@ module Shards
         ary = dep.split(":", 2)
 
         if ary.size == 2
-          "  #{ ary[0] }:\n    mock: \"\"\n    version: #{ ary[1].inspect }"
+          "  #{ ary[0] }:\n    mock: \"test\"\n    version: #{ ary[1].inspect }"
         else
-          "  #{ ary[0] }:\n    mock: \"\""
+          "  #{ ary[0] }:\n    mock: \"test\""
         end
       end
 


### PR DESCRIPTION
Specs are now parsed using the experimental `yaml_mapping` from Crystal 0.8.0. This avoids intermediary memory representations by instanciating objects and to enforce the expected format while parsing the YAML file.

The `yaml_mapping` may be dropped in favor to YAML::PullParser to return useful error messages to the user (with arrows pointing to source errors, etc).

- [x] full parse of `shard.yml` files (eg: license, description)
- [x] parser compliant to the spec, but not fully enforced (`validate` command would take care of this)
- [x] `version` is now required
- [x] `authors` are now objects with #name and #email methods
- [x] parse tests
- [x] tests for failures, with explicit error messages

refs #41