### PR TITLE
Fix: Git >= 1.7.11 may always list in columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_script: |
   bin/shards install
   git config --global user.email "you@example.com"
   git config --global user.name "Your Name"
+  git config --global column.ui always
 
 script:
   - make test

--- a/src/commands/check.cr
+++ b/src/commands/check.cr
@@ -17,7 +17,7 @@ module Shards
 
         manager.packages.each do |package|
           unless package.installed?(loose: true)
-            raise Error.new("Missing #{package.name} (#{package.version})")
+            raise Error.new("Missing #{package.name}")
           end
         end
 

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -4,6 +4,9 @@ module Shards
   RELEASE_VERSION = /^v?([\d\.]+)$/
 
   class GitResolver < Resolver
+    # :nodoc:
+    GIT_COLUMN_NEVER = `git --version` >= "git version 1.7.11" ?  "--column=never" : ""
+
     def self.key
       "git"
     end
@@ -49,7 +52,7 @@ module Shards
       versions = if refs = dependency.refs
                    [version_at(refs), refs]
                  else
-                   capture("git tag --list --no-column")
+                   capture("git tag --list #{ GIT_COLUMN_NEVER }")
                      .split("\n")
                      .map { |version| $1 if version.strip =~ RELEASE_VERSION }
                  end.compact
@@ -118,7 +121,7 @@ module Shards
     def version_at(refs)
       update_local_cache
 
-      tags = capture("git tag --list --contains #{refs}")
+      tags = capture("git tag --list --contains #{refs} #{ GIT_COLUMN_NEVER }")
         .split("\n")
         .map { |tag| $1 if tag =~ RELEASE_VERSION }
         .compact
@@ -130,8 +133,8 @@ module Shards
 
       refs = [] of String?
       refs << commit
-      refs += capture("git tag --list --contains #{commit}").split("\n")
-      refs += capture("git branch --list --contains #{commit}").split(" ")
+      refs += capture("git tag --list --contains #{commit} #{ GIT_COLUMN_NEVER }").split("\n")
+      refs += capture("git branch --list --contains #{commit} #{ GIT_COLUMN_NEVER }").split(" ")
       refs.compact.uniq
     end
 


### PR DESCRIPTION
The global `column.ui` option affects the listings of tags and
branches. This patch fixes this by adding `--column=never` to Git
commands when the installed Git supports the argument.

refs #35