### PR TITLE
remove extra strings from package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dependencies:
 
 development_dependencies:
   minitest:
-    git: https://github.com/ysbaddaden/minitest.cr.git
+    git: ysbaddaden/minitest.cr
     version: ~> 1.0.0
 
 license: MIT


### PR DESCRIPTION
Shards now automatically prefixes pkg name with `https://github.com/` and suffixes `.git` at the end.