### PR TITLE
Fix a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shards
 
-Dependency manager for the [Crystal language](https://crystal-lang.org).
+Dependency manager for the [Crystal language](http://crystal-lang.org).
 
 
 ## Usage


### PR DESCRIPTION
The link at the top of the README pointed at `https://crystal-lang.org` but the site isn't available on port 443 so it was timing out.