### PR TITLE
SSH Github URL instead of HTTPS

### DIFF
--- a/src/resolvers/github.cr
+++ b/src/resolvers/github.cr
@@ -7,7 +7,7 @@ module Shards
     end
 
     def git_url
-      "https://github.com/#{dependency["github"]}.git"
+      "git@github.com:/#{dependency["github"]}.git"
     end
   end
 


### PR DESCRIPTION
I don't think this is the 'right' solution but making the PR now to
discuss it. Maybe there's a right time to use ssh urls and a right time
to make https urls?

Related to #79