### PR TITLE
Drop spec `debug` helper

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -175,7 +175,7 @@ describe "install" do
 
   it "install specific abbreviated commit" do
     metadata = {dependencies: {"web": {git: git_url(:web), commit: git_commits(:web)[2][0...5]}}}
-    with_shard(metadata) { debug "shards install" }
+    with_shard(metadata) { run "shards install" }
     assert_installed "web", "1.2.0", git: git_commits(:web)[2]
   end
 

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -278,11 +278,3 @@ end
 def install_path(*path_names)
   File.join(application_path, Shards::INSTALL_DIR, *path_names)
 end
-
-def debug(command)
-  run "#{command} --verbose"
-rescue ex : FailedCommand
-  puts
-  puts ex.stdout
-  puts ex.stderr
-end


### PR DESCRIPTION
This looks like a development artifact and seems very confusing.