### PR TITLE
docs: fix README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Shards is usually distributed with Crystal itself (e.g. Homebrew and Debian
 packages). Alternatively, a `shards` package may be available for your system.
 
 You can download a source tarball from the same page (or clone the repository)
-then run `make release=1`and copy `bin/shards` into your `PATH`. For
+then run `make release=1` and copy `bin/shards` into your `PATH`. For
 example `/usr/local/bin`.
 
 You are now ready to create a `shard.yml` for your projects (see details in
@@ -90,7 +90,8 @@ Run `make bin/shards` to build the binary.
 - `static=1` for static linking (only works with musl-libc)
 - `debug=1` for full symbolic debug info
 
-Run `make install` to install the binary. Target path can be adjusted with `PREFIX` (default: `PREFIX=/usr/bin`).
+Run `make install` to install the binary. Install prefix can be adjusted with
+`PREFIX` (default: `PREFIX=/usr/local`).
 
 Run `make test` to run the test suites:
 


### PR DESCRIPTION

**Repo:** crystal-lang/shards (⭐ 1000)
**Type:** docs
**Files changed:** 1
**Lines:** +3/-2

## What
This change corrects the README's manual installation instructions by fixing a malformed `make release=1` command example and updating the documented default `PREFIX` for `make install` to match the actual Makefile default of `/usr/local`.

## Why
The existing README could mislead contributors and package maintainers during manual installation. The missing space makes the build command look invalid, and the wrong default `PREFIX` contradicts the project’s Makefile, which can send users looking in the wrong install location after `make install`.

## Testing
Verified the README changes against the current [Makefile](/Users/bojun/Desktop/agent-pr-mission-v2/i/crystal-lang-shards/Makefile), specifically `PREFIX ?= /usr/local` and the documented build/install targets. No code or test suite changes were needed for this docs-only patch.

## Risk
Low + documentation-only change aligned to existing build behavior in the repository.
